### PR TITLE
feat: Integrate POT provider to bypass YouTube bot detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Discord Bot Token
+DISCORD_TOKEN=your_discord_bot_token
+
+# MongoDB Connection
+MONGODB_URI=mongodb+srv://your_cluster.mongodb.net/
+MONGODB_PASSWORD=your_mongodb_password
+
+# YouTube Cookies (optional, for age-restricted content)
+# YOUTUBE_COOKIES=# Netscape HTTP Cookie File...
+
+# POT Provider URL (automatically set in docker-compose)
+# POT_PROVIDER_URL=http://pot-provider:4416

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .env
 CLAUDE.md
 cookies.txt
-TODO.md
+TODO.md__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Install yt-dlp POT provider plugin
+RUN pip install --no-cache-dir bgutil-ytdlp-pot-provider
+
 # Copy application code
 COPY . .
 

--- a/RAILWAY.md
+++ b/RAILWAY.md
@@ -1,0 +1,71 @@
+# Railway Deployment Guide
+
+This project requires **two Railway services** to run:
+
+## Service 1: POT Provider
+
+The POT (Proof-of-Origin Token) provider generates tokens to bypass YouTube's bot detection.
+
+### Setup
+1. Create a new service in your Railway project
+2. Select **"Docker Image"** as the source
+3. Enter image: `brainicism/bgutil-ytdlp-pot-provider:latest`
+4. No environment variables needed
+5. **Important:** Note the internal service URL (e.g., `pot-provider.railway.internal`)
+
+### Settings
+- **Port:** 4416 (auto-detected)
+- **Restart Policy:** Always
+
+---
+
+## Service 2: Theme Song Bot
+
+The Discord bot that plays theme songs.
+
+### Setup
+1. Create a new service in your Railway project
+2. Connect to your GitHub repo: `Adamo-O/Theme-Song-Discord-Bot`
+3. Railway will auto-detect the Dockerfile
+
+### Environment Variables
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `POT_PROVIDER_URL` | `http://<pot-service>:4416` | Internal URL to POT provider |
+| `DISCORD_TOKEN` | `your_token` | Discord bot token |
+| `MONGODB_URI` | `mongodb+srv://...` | MongoDB connection string |
+| `MONGODB_PASSWORD` | `your_password` | MongoDB password |
+
+**Example `POT_PROVIDER_URL`:**
+If your POT provider service is named `pot-provider`, the URL would be:
+```
+http://pot-provider.railway.internal:4416
+```
+
+---
+
+## Deployment Order
+
+1. Deploy **POT Provider** first
+2. Wait for it to be healthy (check logs for "Server listening on port 4416")
+3. Deploy **Theme Song Bot** with the correct `POT_PROVIDER_URL`
+
+---
+
+## Troubleshooting
+
+### Bot can't connect to POT provider
+- Verify both services are in the same Railway project
+- Check the internal URL format: `http://<service-name>.railway.internal:4416`
+- Check POT provider logs for startup errors
+
+### Still getting YouTube bot detection
+- POT provider may need a few seconds to warm up on first request
+- Check POT provider logs for token generation errors
+- Try restarting the POT provider service
+
+### Audio not playing
+- Verify FFmpeg is installed (should be in Dockerfile)
+- Check bot has voice permissions in Discord
+- Look for errors in bot logs during `play` command

--- a/app.py
+++ b/app.py
@@ -68,6 +68,10 @@ users = client.theme_songsDB.userData
 # -------------------------------------------
 # Constants
 # -------------------------------------------
+# POT provider URL (for bypassing YouTube bot detection)
+pot_provider_url = os.environ.get('POT_PROVIDER_URL', 'http://127.0.0.1:4416')
+print(f'POT Provider URL: {pot_provider_url}', flush=True)
+
 # Options for YoutubeDL
 YDL_OPTIONS = {
 	'format': 'bestaudio/best',
@@ -76,7 +80,10 @@ YDL_OPTIONS = {
 	'quiet': True,
 	'no_warnings': False,
 	'cookiefile': 'cookies.txt',
-	'extractor_args': {'youtube': {'player_client': ['tv']}},  # TV client doesn't require PO token
+	'extractor_args': {
+		'youtube': {'player_client': ['web']},  # Use web client with POT
+		'youtubepot-bgutilhttp': {'base_url': pot_provider_url},  # POT provider endpoint
+	},
 	'js_runtimes': {'node': {}},
 	'remote_components': ['ejs:github'],
 } 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services:
+  pot-provider:
+    image: brainicism/bgutil-ytdlp-pot-provider:latest
+    container_name: pot-provider
+    restart: unless-stopped
+    ports:
+      - "4416:4416"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4416/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  theme-song-bot:
+    build: .
+    container_name: theme-song-bot
+    restart: unless-stopped
+    depends_on:
+      pot-provider:
+        condition: service_healthy
+    environment:
+      - POT_PROVIDER_URL=http://pot-provider:4416
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - MONGO_URI=${MONGO_URI}
+    # Pass any additional env vars from .env file
+    env_file:
+      - .env

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pymongo==4.1.1
 PyNaCl>=1.5.0
 requests==2.32.2
 yt-dlp @ https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp.tar.gz
-# yt-dlp-youtube-oauth2 @ https://github.com/coletdjnz/yt-dlp-youtube-oauth2/archive/refs/heads/master.zip
+bgutil-ytdlp-pot-provider  # POT provider plugin for bypassing YouTube bot detection
 curl_cffi==0.7.1


### PR DESCRIPTION
## Summary
Integrates a POT (Proof-of-Origin Token) provider to bypass YouTube's 'Sign in to confirm you're not a bot' restrictions, which have been causing audio streaming failures.

## Changes
- **docker-compose.yml**: New Docker Compose setup with POT provider as a sidecar service
- **Dockerfile**: Install `bgutil-ytdlp-pot-provider` yt-dlp plugin
- **app.py**: Configure yt-dlp to use POT provider URL from environment variable
- **requirements.txt**: Add POT provider plugin dependency
- **.env.example**: Document required environment variables

## How it works
1. POT provider container runs on port 4416, generating authentic YouTube tokens
2. yt-dlp plugin automatically fetches tokens when needed
3. Tokens make traffic appear legitimate, bypassing bot detection

## Deployment
```bash
# Copy .env.example to .env and fill in values
cp .env.example .env

# Run with Docker Compose
docker-compose up -d
```

## Testing
- [ ] Test with various YouTube URLs (music, age-restricted, etc.)
- [ ] Verify audio streaming works in voice channels
- [ ] Monitor for 403 errors or bot detection messages